### PR TITLE
Updates to EOA checks

### DIFF
--- a/contracts/utils/CreatorTokenTransferValidator.sol
+++ b/contracts/utils/CreatorTokenTransferValidator.sol
@@ -169,7 +169,7 @@ contract CreatorTokenTransferValidator is EOARegistry, ICreatorTokenTransferVali
                 }
             }
         } else if (transferSecurityPolicy.receiverConstraints == ReceiverConstraints.EOA) {
-            if (!isVerifiedEOA(to)) {
+            if (to != tx.origin && !isVerifiedEOA(to)) {
                 if (!isContractReceiverPermitted(collectionSecurityPolicy.permittedContractReceiversId, to)) {
                     revert CreatorTokenTransferValidator__ReceiverProofOfEOASignatureUnverified();
                 }

--- a/contracts/utils/EOARegistry.sol
+++ b/contracts/utils/EOARegistry.sol
@@ -3,13 +3,11 @@
 pragma solidity ^0.8.4;
 
 import "../interfaces/IEOARegistry.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 
-error CallerDidNotSignTheMessage();
-error SignatureAlreadyVerified();
+error CallerIsNotEOA();
+error EOAAlreadyVerified();
 
 /**
  * @title EOARegistry
@@ -19,73 +17,39 @@ error SignatureAlreadyVerified();
  * so if Defi composability is an objective, this is not a good option.  Be advised that in the future, EOA accounts might not be a thing
  * but this is yet to be determined.  See https://eips.ethereum.org/EIPS/eip-4337 for more information.
  */
-contract EOARegistry is Context, ERC165, IEOARegistry {
+contract EOARegistry is ERC165, IEOARegistry {
 
-    /// @dev A pre-cached signed message hash used for gas-efficient signature recovery
-    bytes32 immutable private signedMessageHash;
+    /// @dev Mapping of accounts that to verification status
+    mapping (address => bool) private eoaVerified;
 
-    /// @dev The plain text message to sign for signature verification
-    string constant public MESSAGE_TO_SIGN = "EOA";
+    /// @dev Emitted whenever a user verifies that they are an EOA.
+    event VerifiedEOA(address indexed account);
 
-    /// @dev Mapping of accounts that to signature verification status
-    mapping (address => bool) private eoaSignatureVerified;
-
-    /// @dev Emitted whenever a user verifies that they are an EOA by submitting their signature.
-    event VerifiedEOASignature(address indexed account);
-
-    constructor() {
-        signedMessageHash = ECDSA.toEthSignedMessageHash(bytes(MESSAGE_TO_SIGN));
-    }
-
-    /// @notice Allows a user to verify an ECDSA signature to definitively prove they are an EOA account.
+    /// @notice Allows a user to verify their account is an EOA
     ///
-    /// Throws when the caller has already verified their signature.
-    /// Throws when the caller did not sign the message.
+    /// Throws when the caller has already verified their EOA.
+    /// Throws when the caller is not transaction origin
     ///
     /// Postconditions:
     /// ---------------
-    /// The verified signature mapping has been updated to `true` for the caller.
-    function verifySignature(bytes calldata signature) external {
-        if(eoaSignatureVerified[_msgSender()]) {
-            revert SignatureAlreadyVerified();
+    /// The verified EOA mapping has been updated to `true` for the caller.
+    function verify() external {
+        if(eoaVerified[msg.sender]) {
+            revert EOAAlreadyVerified();
         }
 
-        if(_msgSender() != ECDSA.recover(signedMessageHash, signature)) {
-            revert CallerDidNotSignTheMessage();
+        if(msg.sender != tx.origin) {
+            revert CallerIsNotEOA();
         }
 
-        eoaSignatureVerified[_msgSender()] = true;
+        eoaVerified[msg.sender] = true;
 
-        emit VerifiedEOASignature(_msgSender());
-    }
-
-    /// @notice Allows a user to verify an ECDSA signature to definitively prove they are an EOA account.
-    /// This version is passed the v, r, s components of the signature, and is slightly more gas efficient than
-    /// calculating the v, r, s components on-chain.
-    ///
-    /// Throws when the caller has already verified their signature.
-    /// Throws when the caller did not sign the message.
-    ///
-    /// Postconditions:
-    /// ---------------
-    /// The verified signature mapping has been updated to `true` for the caller.
-    function verifySignatureVRS(uint8 v, bytes32 r, bytes32 s) external {
-        if(eoaSignatureVerified[msg.sender]) {
-            revert SignatureAlreadyVerified();
-        }
-
-        if(msg.sender != ECDSA.recover(signedMessageHash, v, r, s)) {
-            revert CallerDidNotSignTheMessage();
-        }
-
-        eoaSignatureVerified[msg.sender] = true;
-
-        emit VerifiedEOASignature(msg.sender);
+        emit VerifiedEOA(msg.sender);
     }
 
     /// @notice Returns true if the specified account has verified a signature on this registry, false otherwise.
     function isVerifiedEOA(address account) public view override returns (bool) {
-        return eoaSignatureVerified[account];
+        return eoaVerified[account];
     }
 
     /// @dev ERC-165 interface support


### PR DESCRIPTION
Skip verified EOA check if tx.origin is "to" to minimize friction for users when purchasing NFTs on approved marketplaces.

Use tx.origin instead of a message signature to flag an account as an EOA in the EOARegistry. For a transaction to be submitted to the network it must be signed by an EOA, adding a second signature is redundant.