### PR TITLE
Add Transfer Disabled Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Interact with the deployed contract using the provided functions to create, mana
 
 For more information, please refer to the contract code comments and the provided function descriptions.
 
-The `CreatorTokenTransferValidator` contract defines 7 transfer security levels, each represented by a unique `TransferSecurityPolicy`. Each policy consists of a combination of caller and receiver constraints to define varying levels of security for token transfers.
+The `CreatorTokenTransferValidator` contract defines 8 transfer security levels, each represented by a unique `TransferSecurityPolicy`. Each policy consists of a combination of caller and receiver constraints to define varying levels of security for token transfers.
 
 #### **Transfer Security Levels Description**
 
@@ -283,6 +283,12 @@ The `CreatorTokenTransferValidator` contract defines 7 transfer security levels,
    - Caller Constraints: OperatorWhitelistDisableOTC
    - Receiver Constraints: EOA
    - The caller must be whitelisted as an operator, and OTC transfers initiated by the token owner are not allowed. The receiver must be an EOA, which means they cannot be a smart contract and must have performed a one-time signature verification in the `CreatorTokenTransferValidator`.  Specific contract receivers can optionally be designated in a permitted contract receivers allowlist.
+
+7. **TransferSecurityLevels.Seven:**
+
+   - Caller Constraints: Disabled
+   - Receiver Constraints: Disabled
+   - This security level blocks all transfers, effectively making the token soulbound.
 
 These predefined transfer security levels can be applied to collections to implement varying levels of transfer security based on the collection's requirements.
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ contract MyCollection is ERC721CW {
 
 6. To set up a collection to use the default security settings, call the `setToDefaultSecurityPolicy` function on your NFT contract using Etherscan or Gnosis Safe UIs.  Alternately, to set up a collection to use custom security settings, call the `setToCustomSecurityPolicy` function on your NFT contract with the custom validator address, security level, operator whitelist ID, and permitted contract receiver allowlist ID.
 
-7. By default, any address can stake.  But to apply staking constraints to prevent contracts from staking to wrap token, the contract owner can use the `setStakerConstraints(StakerConstraints stakerConstraints_)` function with `StakerConstraints.None`, `StakerConstraints.CallerIsTxOrigin`, or `StakerConstraints.EOA`.
+7. By default, any address can stake.  But to apply staking constraints to prevent contracts from staking to wrap token, the contract owner can use the `setStakerConstraints(StakerConstraints stakerConstraints_)` function with `StakerConstraints.None`, `StakerConstraints.CallerIsTxOrigin`, or `StakerConstraints.EOA`, or `StakerConstraints.Disabled`.
 
 ## How To Implement Programmable Royalties Using A Mix-In
 

--- a/contracts/erc1155c/extensions/ERC1155CW.sol
+++ b/contracts/erc1155c/extensions/ERC1155CW.sol
@@ -28,6 +28,7 @@ abstract contract ERC1155WrapperBase is WithdrawETH, ReentrancyGuard, ICreatorTo
     error ERC1155WrapperBase__DefaultImplementationOfUnstakeDoesNotAcceptPayment();
     error ERC1155WrapperBase__InvalidERC1155Collection();
     error ERC1155WrapperBase__SmartContractsNotPermittedToStake();
+    error ERC1155WrapperBase__StakeDisabled();
 
     /// @dev Points to an external ERC1155 contract that will be wrapped via staking.
     IERC1155 private wrappedCollection;
@@ -76,6 +77,8 @@ abstract contract ERC1155WrapperBase is WithdrawETH, ReentrancyGuard, ICreatorTo
             }
         } else if (stakerConstraints_ == StakerConstraints.EOA) {
             _requireCallerIsVerifiedEOA();
+        } else if (stakerConstraints_ == StakerConstraints.Disabled) {
+            revert ERC1155WrapperBase__StakeDisabled();
         }
 
         if (amount == 0) {

--- a/contracts/erc721c/extensions/ERC721CW.sol
+++ b/contracts/erc721c/extensions/ERC721CW.sol
@@ -25,6 +25,7 @@ abstract contract ERC721WrapperBase is WithdrawETH, ICreatorTokenWrapperERC721 {
     error ERC721WrapperBase__DefaultImplementationOfUnstakeDoesNotAcceptPayment();
     error ERC721WrapperBase__InvalidERC721Collection();
     error ERC721WrapperBase__SmartContractsNotPermittedToStake();
+    error ERC721WrapperBase__StakeDisabled();
 
     /// @dev Points to an external ERC721 contract that will be wrapped via staking.
     IERC721 private wrappedCollection;
@@ -72,6 +73,8 @@ abstract contract ERC721WrapperBase is WithdrawETH, ICreatorTokenWrapperERC721 {
             }
         } else if (stakerConstraints_ == StakerConstraints.EOA) {
             _requireCallerIsVerifiedEOA();
+        } else if (stakerConstraints_ == StakerConstraints.Disabled) {
+            revert ERC721WrapperBase__StakeDisabled();
         }
 
         IERC721 wrappedCollection_ = IERC721(getWrappedCollectionAddress());

--- a/contracts/utils/TransferPolicy.sol
+++ b/contracts/utils/TransferPolicy.sol
@@ -9,13 +9,15 @@ enum AllowlistTypes {
 enum ReceiverConstraints {
     None,
     NoCode,
-    EOA
+    EOA,
+    Disabled
 }
 
 enum CallerConstraints {
     None,
     OperatorWhitelistEnableOTC,
-    OperatorWhitelistDisableOTC
+    OperatorWhitelistDisableOTC,
+    Disabled
 }
 
 enum StakerConstraints {
@@ -31,7 +33,8 @@ enum TransferSecurityLevels {
     Three,
     Four,
     Five,
-    Six
+    Six,
+    Seven
 }
 
 struct TransferSecurityPolicy {

--- a/contracts/utils/TransferPolicy.sol
+++ b/contracts/utils/TransferPolicy.sol
@@ -23,7 +23,8 @@ enum CallerConstraints {
 enum StakerConstraints {
     None,
     CallerIsTxOrigin,
-    EOA
+    EOA,
+    Disabled
 }
 
 enum TransferSecurityLevels {

--- a/test/CreatorTokenTransferValidatorERC1155.t.sol
+++ b/test/CreatorTokenTransferValidatorERC1155.t.sol
@@ -108,6 +108,14 @@ contract CreatorTokenTransferValidatorERC1155Test is Test {
         assertTrue(receiverConstraints == ReceiverConstraints.EOA);
     }
 
+    function testTransferSecurityLevelSeven() public {
+        (CallerConstraints callerConstraints, ReceiverConstraints receiverConstraints) =
+            validator.transferSecurityPolicies(TransferSecurityLevels.Seven);
+        assertEq(uint8(TransferSecurityLevels.Seven), 7);
+        assertTrue(callerConstraints == CallerConstraints.Disabled);
+        assertTrue(receiverConstraints == ReceiverConstraints.Disabled);
+    }
+
     function testCreateOperatorWhitelist(address listOwner, string memory name) public {
         vm.assume(listOwner != address(0));
         vm.assume(bytes(name).length < 200);
@@ -375,7 +383,7 @@ contract CreatorTokenTransferValidatorERC1155Test is Test {
 
     function testGetSecurityPolicyReturnsExpectedSecurityPolicy(address creator, uint8 levelUint8) public {
         vm.assume(creator != address(0));
-        vm.assume(levelUint8 >= 0 && levelUint8 <= 6);
+        vm.assume(levelUint8 >= 0 && levelUint8 <= 7);
 
         TransferSecurityLevels level = TransferSecurityLevels(levelUint8);
 
@@ -398,7 +406,7 @@ contract CreatorTokenTransferValidatorERC1155Test is Test {
 
     function testSetCustomSecurityPolicy(address creator, uint8 levelUint8) public {
         vm.assume(creator != address(0));
-        vm.assume(levelUint8 >= 0 && levelUint8 <= 6);
+        vm.assume(levelUint8 >= 0 && levelUint8 <= 7);
 
         TransferSecurityLevels level = TransferSecurityLevels(levelUint8);
 
@@ -422,7 +430,7 @@ contract CreatorTokenTransferValidatorERC1155Test is Test {
 
     function testSetTransferSecurityLevelOfCollection(address creator, uint8 levelUint8) public {
         vm.assume(creator != address(0));
-        vm.assume(levelUint8 >= 0 && levelUint8 <= 6);
+        vm.assume(levelUint8 >= 0 && levelUint8 <= 7);
 
         TransferSecurityLevels level = TransferSecurityLevels(levelUint8);
 
@@ -879,6 +887,16 @@ contract CreatorTokenTransferValidatorERC1155Test is Test {
         validator.setTransferSecurityLevelOfCollection(address(token), TransferSecurityLevels.Zero);
         vm.stopPrank();
         assertTrue(token.isTransferAllowed(caller, from, to));
+    }
+
+    function testPolicyLevelSevenBlocksAllTransfers(address creator, address caller, address from, address to) public {
+        vm.assume(creator != address(0));
+        ITestCreatorToken1155 token = _deployNewToken(creator);
+        vm.startPrank(creator);
+        token.setTransferValidator(address(validator));
+        validator.setTransferSecurityLevelOfCollection(address(token), TransferSecurityLevels.Seven);
+        vm.stopPrank();
+        assertFalse(token.isTransferAllowed(caller, from, to));
     }
 
     function testWhitelistPoliciesWithOTCEnabledBlockTransfersWhenCallerNotWhitelistedOrOwner(

--- a/test/adventures/AdventureERC721CW.t.sol
+++ b/test/adventures/AdventureERC721CW.t.sol
@@ -244,7 +244,7 @@ contract AdventureERC721CWTest is CreatorTokenTransferValidatorERC721Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -258,7 +258,7 @@ contract AdventureERC721CWTest is CreatorTokenTransferValidatorERC721Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -370,6 +370,24 @@ contract AdventureERC721CWTest is CreatorTokenTransferValidatorERC721Test {
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakingDisabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 
@@ -662,7 +680,7 @@ contract AdventureERC721CWInitializableTest is CreatorTokenTransferValidatorERC7
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -676,7 +694,7 @@ contract AdventureERC721CWInitializableTest is CreatorTokenTransferValidatorERC7
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -788,6 +806,24 @@ contract AdventureERC721CWInitializableTest is CreatorTokenTransferValidatorERC7
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakeDisabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 

--- a/test/wrappers/ERC1155CW.t.sol
+++ b/test/wrappers/ERC1155CW.t.sol
@@ -392,7 +392,7 @@ contract ERC1155CWTest is CreatorTokenTransferValidatorERC1155Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -406,7 +406,7 @@ contract ERC1155CWTest is CreatorTokenTransferValidatorERC1155Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -538,6 +538,27 @@ contract ERC1155CWTest is CreatorTokenTransferValidatorERC1155Test {
 
         vm.prank(to);
         vm.expectRevert(ERC1155WrapperBase.ERC1155WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId, amount);
+    }
+
+    function testRevertsWhenStakeDisabled(
+        address to,
+        uint256 tokenId,
+        uint256 amount
+    ) public {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+        vm.assume(to.code.length == 0);
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId, amount);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC1155WrapperBase.ERC1155WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId, amount);
     }
 

--- a/test/wrappers/ERC1155CWPaidUnstake.t.sol
+++ b/test/wrappers/ERC1155CWPaidUnstake.t.sol
@@ -439,7 +439,7 @@ contract ERC1155CWPaidUnstakeTest is CreatorTokenTransferValidatorERC1155Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -453,7 +453,7 @@ contract ERC1155CWPaidUnstakeTest is CreatorTokenTransferValidatorERC1155Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         vm.assume(unauthorizedUser != tokenMock.owner());
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
@@ -589,6 +589,28 @@ contract ERC1155CWPaidUnstakeTest is CreatorTokenTransferValidatorERC1155Test {
 
         vm.prank(to);
         vm.expectRevert(ERC1155WrapperBase.ERC1155WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId, amount);
+    }
+
+    function testRevertsWhenStakeDisabled(
+        address to,
+        uint256 tokenId,
+        uint256 amount
+    ) public {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+        vm.assume(to != address(tokenMock));
+        vm.assume(to.code.length == 0);
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId, amount);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC1155WrapperBase.ERC1155WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId, amount);
     }
 

--- a/test/wrappers/ERC1155CWPermanent.t.sol
+++ b/test/wrappers/ERC1155CWPermanent.t.sol
@@ -373,7 +373,7 @@ contract ERC1155CWPermanentTest is CreatorTokenTransferValidatorERC1155Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -387,7 +387,7 @@ contract ERC1155CWPermanentTest is CreatorTokenTransferValidatorERC1155Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -518,6 +518,27 @@ contract ERC1155CWPermanentTest is CreatorTokenTransferValidatorERC1155Test {
 
         vm.prank(to);
         vm.expectRevert(ERC1155WrapperBase.ERC1155WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId, amount);
+    }
+
+    function testRevertsWhenStakeDisabled(
+        address to,
+        uint256 tokenId,
+        uint256 amount
+    ) public {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+        vm.assume(to.code.length == 0);
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId, amount);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC1155WrapperBase.ERC1155WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId, amount);
     }
 

--- a/test/wrappers/ERC721CW.t.sol
+++ b/test/wrappers/ERC721CW.t.sol
@@ -257,7 +257,7 @@ contract ERC721CWTest is CreatorTokenTransferValidatorERC721Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -271,7 +271,7 @@ contract ERC721CWTest is CreatorTokenTransferValidatorERC721Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -383,6 +383,24 @@ contract ERC721CWTest is CreatorTokenTransferValidatorERC721Test {
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakeDisbabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 
@@ -667,7 +685,7 @@ contract ERC721CWInitializableTest is CreatorTokenTransferValidatorERC721Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -681,7 +699,7 @@ contract ERC721CWInitializableTest is CreatorTokenTransferValidatorERC721Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -793,6 +811,24 @@ contract ERC721CWInitializableTest is CreatorTokenTransferValidatorERC721Test {
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakeDisabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 

--- a/test/wrappers/ERC721CWPaidUnstake.t.sol
+++ b/test/wrappers/ERC721CWPaidUnstake.t.sol
@@ -264,7 +264,7 @@ contract ERC721CWPaidUnstakeTest is CreatorTokenTransferValidatorERC721Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -278,7 +278,7 @@ contract ERC721CWPaidUnstakeTest is CreatorTokenTransferValidatorERC721Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -390,6 +390,24 @@ contract ERC721CWPaidUnstakeTest is CreatorTokenTransferValidatorERC721Test {
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakeDisabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 

--- a/test/wrappers/ERC721CWPermanent.t.sol
+++ b/test/wrappers/ERC721CWPermanent.t.sol
@@ -234,7 +234,7 @@ contract ERC721CWPermanentTest is CreatorTokenTransferValidatorERC721Test {
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -248,7 +248,7 @@ contract ERC721CWPermanentTest is CreatorTokenTransferValidatorERC721Test {
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -360,6 +360,24 @@ contract ERC721CWPermanentTest is CreatorTokenTransferValidatorERC721Test {
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakeDisabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 

--- a/test/wrappers/ERC721CWTimeLockedUnstake.t.sol
+++ b/test/wrappers/ERC721CWTimeLockedUnstake.t.sol
@@ -325,7 +325,7 @@ contract ERC721CWTimeLockedUnstakeTest is CreatorTokenTransferValidatorERC721Tes
     }
 
     function testCanSetStakerConstraints(uint8 constraintsUint8) public {
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.expectEmit(false, false, false, true);
@@ -339,7 +339,7 @@ contract ERC721CWTimeLockedUnstakeTest is CreatorTokenTransferValidatorERC721Tes
         uint8 constraintsUint8
     ) public {
         vm.assume(unauthorizedUser != address(0));
-        vm.assume(constraintsUint8 <= 2);
+        vm.assume(constraintsUint8 <= 3);
         StakerConstraints constraints = StakerConstraints(constraintsUint8);
 
         vm.prank(unauthorizedUser);
@@ -453,6 +453,24 @@ contract ERC721CWTimeLockedUnstakeTest is CreatorTokenTransferValidatorERC721Tes
 
         vm.prank(to);
         vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__CallerSignatureNotVerifiedInEOARegistry.selector);
+        tokenMock.stake(tokenId);
+    }
+
+    function testRevertsWhenStakeDisabled(address to, uint256 tokenId)
+        public
+    {
+        _sanitizeAddress(to);
+        vm.assume(to != address(0));
+
+        vm.startPrank(to);
+        wrappedTokenMock.mint(to, tokenId);
+        wrappedTokenMock.setApprovalForAll(address(tokenMock), true);
+        vm.stopPrank();
+
+        tokenMock.setStakerConstraints(StakerConstraints.Disabled);
+
+        vm.prank(to);
+        vm.expectRevert(ERC721WrapperBase.ERC721WrapperBase__StakeDisabled.selector);
         tokenMock.stake(tokenId);
     }
 


### PR DESCRIPTION
Adds a new Security Level that disables all transfers. This effectively make a token soul bound while in this level. 
I've also added `StakerConstraints.Disabled` for parity. 

Commits are separate and can be cherry-picked if only one change is desired. 

**Note!**
This should be the maximum level. If more security requirements (and levels) are introduced, it would make sense to bump this up. However, that would affect any tokens that use an upgradable mechanism.  
I considered using a high value like `type(uint256).max`, however using level 7 felt a lot cleaner. 